### PR TITLE
fix: variables in loop

### DIFF
--- a/src/components/title-text-component.html
+++ b/src/components/title-text-component.html
@@ -2,9 +2,9 @@
   <tr>
     <td class="p-4 bg-green-100">
       <table class="w-full">
-        <if condition="items">
-          <each loop="item, index in items">
-            
+        <if condition="page.dataFromConfig">
+          <each loop="item, index in page.dataFromConfig">
+
             <!-- rendering single items -->
             <tr>
               <table class="w-full">

--- a/src/templates/testtemplate.html
+++ b/src/templates/testtemplate.html
@@ -1,11 +1,5 @@
 <extends src="src/layouts/master.html">
   <block name="template">
-    
-    <component src="src/components/title-text-component.html" locals='{
-      "items": "{{ page.dataFromConfig }}"
-    }'>
-      
-    </component>
-
+    <component src="src/components/title-text-component.html" />
   </block>
 </extends>


### PR DESCRIPTION
- removed `locals` attribute since `{{ }}` expressions are not evaluated inside it
- used the `page` object in the component to access the `dataFromConfig` variable